### PR TITLE
Access actual filter-strategy alias for key in model-specific strategy-configuration.

### DIFF
--- a/src/Stores/Filtering/DefaultFilter.php
+++ b/src/Stores/Filtering/DefaultFilter.php
@@ -194,7 +194,7 @@ class DefaultFilter extends Filter implements FilterHandlerInterface
         $modelClass = get_class($this->model);
 
         return config(
-            "datastore.filter.strategies.{$modelClass}",
+            "datastore.filter.strategies.{$modelClass}.{$key}",
             config("datastore.filter.default-strategies.{$key}", $this->determineStrategyDefault($key))
         );
     }


### PR DESCRIPTION
According to [this comment in the config template](https://github.com/czim/laravel-datastore/blob/master/config/datastore.php#L139) Filter strategies can be specified on a model- and key-specific basis.

Therefore, The method [`DefaultFilter::determineStrategyForKey($key)`](https://github.com/czim/laravel-datastore/blob/master/src/Stores/Filtering/DefaultFilter.php#L192) should actually access member `$key` inside the model's `filter-attribute => strategy-alias` map, rather than giving back the entire config array of the respective model.